### PR TITLE
Add recipe for cm-config repo porting

### DIFF
--- a/recipes-akraino/cm-plugins/activators.inc
+++ b/recipes-akraino/cm-plugins/activators.inc
@@ -1,0 +1,18 @@
+PACKAGES += " activators"
+
+RDEPENDS_activators += " bash python"
+
+do_configure_prepend () {
+} 
+
+do_compile_prepend () {
+}
+
+do_install_prepend () {
+	install -d -m 0755 ${D}/opt/cmframework/activators
+    find activators -name '*.py' -exec cp {} ${D}/opt/cmframework/activators/ \;
+}
+
+FILES_activators = " \
+	/opt/cmframework/activators/ \
+	"

--- a/recipes-akraino/cm-plugins/cm-plugins_git.bb
+++ b/recipes-akraino/cm-plugins/cm-plugins_git.bb
@@ -1,0 +1,45 @@
+DESCRIPTION = "Plugins for configuration manager"
+
+STABLE = "master"
+PROTOCOL = "https"
+BRANCH = "master"
+SRCREV = "b3603a371a729a17e5130216fc71d67b6f0827e8"
+S = "${WORKDIR}/git"
+
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+SRC_URI = "git://gerrit.akraino.org/r/ta/cm-plugins.git;protocol=${PROTOCOL};rev=${SRCREV};branch=${BRANCH}"
+
+inherit akraino-version
+
+DEPENDS += " \
+	"
+
+require activators.inc
+require inventoryhandlers.inc
+require recuserconfighandlers.inc
+require userconfighandlers.inc
+require validators.inc
+
+
+do_configure () {
+	:
+} 
+
+do_compile() {
+	:	
+}
+
+do_install () {
+	:
+}
+
+pkg_postinst_ontarget_${PN} () {
+}
+
+#FILES_${PN} = " "
+#FILES_${PN}-dev += " \
+#	var/lib/sm/watchdog/modules/libsm_watchdog_nfs.so \
+#	"

--- a/recipes-akraino/cm-plugins/inventoryhandlers.inc
+++ b/recipes-akraino/cm-plugins/inventoryhandlers.inc
@@ -1,0 +1,18 @@
+PACKAGES += " inventoryhandlers"
+
+RDEPENDS_inventoryhandlers += " bash python"
+
+do_configure_prepend () {
+} 
+
+do_compile_prepend () {
+}
+
+do_install_prepend () {
+	install -d -m 0755 ${D}/opt/cmframework/inventoryhandlers
+    find inventoryhandlers -name '*.py' -exec cp {} ${D}/opt/cmframework/inventoryhandlers \;
+}
+
+FILES_inventoryhandlers = " \
+	/opt/cmframework/inventoryhandlers \
+	"

--- a/recipes-akraino/cm-plugins/recuserconfighandlers.inc
+++ b/recipes-akraino/cm-plugins/recuserconfighandlers.inc
@@ -1,0 +1,20 @@
+PACKAGES += " recuserconfighandlers"
+
+ALLOW_EMPTY_recuserconfighandlers = "1"
+
+RDEPENDS_recuserconfighandlers += " bash python"
+
+do_configure_prepend () {
+} 
+
+do_compile_prepend () {
+}
+
+do_install_prepend () {
+	install -d -m 0755 ${D}/opt/cmframework/userconfighandlers
+    find recuserconfighandlers -name '*.py' -exec cp {} ${D}/opt/cmframework/userconfighandlers \;
+}
+
+FILES_recuserconfighandlers = " \
+	/opt/cmframework/userconfighandlers \
+	"

--- a/recipes-akraino/cm-plugins/userconfighandlers.inc
+++ b/recipes-akraino/cm-plugins/userconfighandlers.inc
@@ -1,0 +1,20 @@
+PACKAGES += " userconfighandlers"
+
+ALLOW_EMPTY_userconfighandlers = "1"
+
+RDEPENDS_userconfighandlers += " bash python"
+
+do_configure_prepend () {
+} 
+
+do_compile_prepend () {
+}
+
+do_install_prepend () {
+	install -d -m 0755 ${D}/opt/cmframework/userconfighandlers
+    find userconfighandlers -name '*.py' -exec cp {} ${D}/opt/cmframework/userconfighandlers \;
+}
+
+FILES_userconfighandlers = " \
+	/opt/cmframework/userconfighandlers \
+	"

--- a/recipes-akraino/cm-plugins/validators.inc
+++ b/recipes-akraino/cm-plugins/validators.inc
@@ -1,0 +1,18 @@
+PACKAGES += " validators"
+
+RDEPENDS_validators += " bash python"
+
+do_configure_prepend () {
+} 
+
+do_compile_prepend () {
+}
+
+do_install_prepend () {
+	install -d -m 0755 ${D}/opt/cmframework/validators
+    find validators -name '*.py' -exec cp {} ${D}/opt/cmframework/validators \;
+}
+
+FILES_validators = " \
+	/opt/cmframework/validators \
+	"


### PR DESCRIPTION
Add recipe for cm-config repo porting, which will generate:   
    activators
    inventoryhandlers
    recuserconfighandlers
    userconfighandlers
    validators

five packages.