### PR TITLE
Add recipes:

### DIFF
--- a/recipes-akraino/image-provision/image-provision_git.bb
+++ b/recipes-akraino/image-provision/image-provision_git.bb
@@ -1,0 +1,42 @@
+DESCRIPTION = "Contains dracut modules used for provisioning master image from a boot CD."
+HOMEPAGE = "https://gerrit.akraino.org/r/ta/image-provision"
+SECTION = "devel/utils"
+LICENSE = "Apache-2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+STABLE = "master"
+PROTOCOL = "https"
+BRANCH = "master"
+SRCREV = "b5a73c42ad43ce29f7ceb6c5997d30476f4e931a"
+PV = "1.0+git${SRCPV}"
+S = "${WORKDIR}/git"
+
+SRC_URI = "git://gerrit.akraino.org/r/ta/image-provision.git;protocol=${PROTOCOL};rev=${SRCREV};branch=${BRANCH}"
+
+inherit akraino-version
+
+DEPENDS_${PN} += " \
+        bash \
+        rsync-native \
+        "
+
+RDEPENDS_${PN} += " \
+        bash \
+        cloud-init \
+        dracut \
+        "
+
+do_install() {
+
+        mkdir -p ${D}/usr/lib/dracut/modules.d/
+        mkdir -p ${D}/etc/
+        
+        /usr/bin/rsync -rlpD dracut/modules/00installmedia ${D}/usr/lib/dracut/modules.d/
+        /usr/bin/rsync -rlpD dracut/modules/00readfloppyconf ${D}/usr/lib/dracut/modules.d/
+        /usr/bin/rsync -rlpD dracut/modules/00readcdconf ${D}/usr/lib/dracut/modules.d/
+        /usr/bin/rsync -rlpD dracut/modules/00netconfig ${D}/usr/lib/dracut/modules.d/
+        /usr/bin/rsync -rlpD dracut/conf/dracut-provision.conf  ${D}/etc/
+
+}
+
+FILES_${PN} = "${libdir}/dracut/modules.d/* /etc/*"

--- a/recipes-akraino/python/lockcli_git.bb
+++ b/recipes-akraino/python/lockcli_git.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "This RPM contains source code for the lock cli"
+HOMEPAGE = "https://gerrit.akraino.org/r/ta/lockcli"
+SECTION = "devel/python"
+LICENSE = "Apache-2"
+LIC_FILES_CHKSUM = "file://../LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+STABLE = "master"
+PROTOCOL = "https"
+BRANCH = "master"
+SRCREV = "54aed66cdaef170ffbfdcb511ced241f4be14555"
+S = "${WORKDIR}/git/src"
+
+SRC_URI = "git://gerrit.akraino.org/r/ta/lockcli.git;protocol=${PROTOCOL};rev=${SRCREV};branch=${BRANCH}"
+
+inherit setuptools akraino-version
+
+RDEPENDS_${PN} += " \
+        etcd \
+        python-etcd \
+        "


### PR DESCRIPTION
image-provision
lockcli
Delete package manifest, because yocto use os-release to record build version